### PR TITLE
Fix header link to Github

### DIFF
--- a/src/components/header.js
+++ b/src/components/header.js
@@ -26,12 +26,12 @@ const Header = ({ siteTitle }) => (
         >
           {siteTitle}
         </Link>{' '}
-        <Link
-          to="https://github.com/grantcodes/micropub-post-demos"
+        <a
+          href="https://github.com/grantcodes/micropub-post-demos"
           style={{ fontSize: '.5em', color: 'ghostwhite' }}
         >
           Contribute on Github
-        </Link>
+        </a>
       </h1>
     </div>
   </div>


### PR DESCRIPTION
The Gatsby Link component only works for internal links. Switch to an old-fashioned `<a>` for the Github link.